### PR TITLE
layout.conf: add manifest-hashes required by manifest-required-hashes

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,5 +1,5 @@
 masters = gentoo
 thin-manifests = true
 use-manifests = strict
-manifest-hashes = SHA512
+manifest-hashes = SHA256 SHA512 WHIRLPOOL
 manifest-required-hashes = SHA512

--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,4 +1,5 @@
 masters = gentoo
 thin-manifests = true
 use-manifests = strict
+manifest-hashes = SHA512
 manifest-required-hashes = SHA512


### PR DESCRIPTION
It is required that `manifest-required-hashes` is used only if `manifest-hashes` is declared as its superset.